### PR TITLE
Fix site preferences for ChatGPT legacy domain

### DIFF
--- a/utils/sitePreferences.js
+++ b/utils/sitePreferences.js
@@ -7,6 +7,7 @@
 export function getDefaultSitePreferences() {
   return {
     "chatgpt.com": { enabled: true },
+    "chat.openai.com": { enabled: true },
     "claude.ai": { enabled: true },
     "gemini.google.com": { enabled: true },
     "lovable.dev": { enabled: true },


### PR DESCRIPTION
## Summary
- include `chat.openai.com` in the default allowed sites

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_688c1f5e73cc8327aca1f2cb842a46b6